### PR TITLE
Fix a typo [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ThinreportsRails
-ThinReporsRails is constructed by Rails Template Handler [ThinReports](http://www.thinreports.org/ "ThinReposts") the PDF.
+ThinreportsRails is constructed by Rails Template Handler [ThinReports](http://www.thinreports.org/ "ThinReposts") the PDF.
 
 [![Build Status](https://travis-ci.org/takeshinoda/thinreports-rails.svg?branch=master)](https://travis-ci.org/takeshinoda/thinreports-rails)
 


### PR DESCRIPTION
I found a typo in `README.md`.