### PR TITLE
support thinreports 0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Oldname: thinreports-handler
 
 * Ruby 1.9.3, 2.0.X, 2.1.X, 2.2.X, 2.3.X
 * Rails 3.X, 4.X
-* ThinReports 0.9.1 later
+* ThinReports 0.10.0 or later
 
 ## Installation
 
@@ -41,7 +41,7 @@ end
 
 #### Views
 
-app/views/orders/index.pdf.thinreports 
+app/views/orders/index.pdf.thinreports
 
 ``` ruby
 report.start_new_page
@@ -61,7 +61,7 @@ class OrdersController < ApplicationController
   def index
     @orders = Order.all
     respond_to do |format|
-      format.pdf { 
+      format.pdf {
         send_data render_to_string, filename: 'foo.pdf', type: 'application/pdf', disposition: 'attachment'
       }
     end
@@ -69,7 +69,7 @@ class OrdersController < ApplicationController
 end
 ```
 
-### Configuration 
+### Configuration
 
 ### Layout file(.tlf) and options.
 
@@ -84,13 +84,13 @@ report.set_layout tlf: 'reports/index', layout_options: { default: true }
 
 ### generate options.
 ``` ruby
-report.generate_options(security: { 
+report.generate_options(security: {
   user_password: 'foo',
   owner_password: 'bar',
-  permissions: { 
+  permissions: {
     print_document: false,
     modify_contents: false,
-    copy_contents: false 
+    copy_contents: false
   }
 })
 ```
@@ -116,4 +116,3 @@ m(__)m, send me pull request.
 ## Copyright
 
 Copyright (c) 2012 Takeshi Shinoda.
-

--- a/lib/thinreports-rails/template_handler.rb
+++ b/lib/thinreports-rails/template_handler.rb
@@ -4,7 +4,7 @@ require 'active_support/core_ext'
 require 'thinreports'
 
 module ThinreportsRails
-  class ThinreportsTemplate < SimpleDelegator  
+  class ThinreportsTemplate < SimpleDelegator
     attr_accessor :_generate_options
 
     def initialize(thinreports_report_base_obj, template_context, template_virtual_path)
@@ -56,8 +56,8 @@ module ThinreportsRails
           #{template.source}
         else
           generate_options = nil
-          ThinReports::Report.create do |__report__|
-            report = ThinreportsRails::ThinreportsTemplate.new(__report__, self, '#{template.virtual_path}') 
+          Thinreports::Report.create do |__report__|
+            report = ThinreportsRails::ThinreportsTemplate.new(__report__, self, '#{template.virtual_path}')
             report.set_layout :allow_no_layout => true
 
             #{template.source}
@@ -71,4 +71,3 @@ module ThinreportsRails
 end
 
 ActionView::Template.register_template_handler :thinreports, ThinreportsRails::TemplateHandler
-

--- a/test/thinreports-rails_test.rb
+++ b/test/thinreports-rails_test.rb
@@ -18,7 +18,7 @@ require 'rails/test_help'
 require 'thinreports-rails'
 require 'test_app/test_app'
 
-class ThinReportsRailsTest < ActionController::TestCase
+class ThinreportsRailsTest < ActionController::TestCase
   tests OrdersController
 
   test 'index.tlf is selected.' do
@@ -40,4 +40,3 @@ class ThinReportsRailsTest < ActionController::TestCase
     assert_raise(ActionView::Template::Error) { get :no_tlf, :format => :pdf }
   end
 end
-


### PR DESCRIPTION
thinreports ver. 0.10.0 was released and top-module name "ThinReports" was changed to "Thinreports".  So we need to change thinreports-rails slightly.

Please see http://www.thinreports.org/news/2017/05/thinreports-generator-0_10_0-released/ for detail.