### PR TITLE
Support Thinreports 0.10.0 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ sudo: false
 rvm:
   - 2.4.1
   - 2.3.1
+  - 2.2.4
   - 2.2
   - 2.1
 
@@ -17,8 +18,26 @@ gemfile:
   - gemfiles/Gemfile-rails.4.0.x
   - gemfiles/Gemfile-rails.4.1.x
   - gemfiles/Gemfile-rails.4.2.x
+  - gemfiles/Gemfile-rails.5.0.x
+  - gemfiles/Gemfile-rails.5.1.x
 
 matrix:
-  allow_failures:
-    - rvm: 1.9.3
-
+  exclude:
+    - rvm: 2.1
+      gemfile: gemfiles/Gemfile-rails.5.0.x
+    - rvm: 2.1
+      gemfile: gemfiles/Gemfile-rails.5.1.x
+    - rvm: 2.2
+      gemfile: gemfiles/Gemfile-rails.5.0.x
+    - rvm: 2.2
+      gemfile: gemfiles/Gemfile-rails.5.1.x
+    - rvm: 2.4.1
+      gemfile: gemfiles/Gemfile-rails.3.0.x
+    - rvm: 2.4.1
+      gemfile: gemfiles/Gemfile-rails.3.1.x
+    - rvm: 2.4.1
+      gemfile: gemfiles/Gemfile-rails.3.2.x
+    - rvm: 2.4.1
+      gemfile: gemfiles/Gemfile-rails.4.0.x
+    - rvm: 2.4.1
+      gemfile: gemfiles/Gemfile-rails.4.1.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ script: ruby test/thinreports-rails_test.rb
 sudo: false
 
 rvm:
+  - 2.4.1
   - 2.3.1
   - 2.2
   - 2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ rvm:
   - 2.3.1
   - 2.2
   - 2.1
-  - 2.0
-  - 1.9.3
 
 gemfile:
   - gemfiles/Gemfile-rails.3.0.x

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Oldname: thinreports-handler
 
 ## Supported versions
 
-* Ruby 1.9.3, 2.0.X, 2.1.X, 2.2.X, 2.3.X
-* Rails 3.X, 4.X
+* Ruby 2.1.X, 2.2.X, 2.3.X
+* Rails 3.X, 4.X, 5.X
 * ThinReports 0.10.0 or later
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Oldname: thinreports-handler
 
 * Ruby 1.9.3, 2.0.X, 2.1.X, 2.2.X, 2.3.X
 * Rails 3.X, 4.X
-* ThinReports 0.9.1 later
+* ThinReports 0.10.0 or later
 
 ## Installation
 
@@ -41,7 +41,7 @@ end
 
 #### Views
 
-app/views/orders/index.pdf.thinreports 
+app/views/orders/index.pdf.thinreports
 
 ``` ruby
 report.start_new_page
@@ -61,7 +61,7 @@ class OrdersController < ApplicationController
   def index
     @orders = Order.all
     respond_to do |format|
-      format.pdf { 
+      format.pdf {
         send_data render_to_string, filename: 'foo.pdf', type: 'application/pdf', disposition: 'attachment'
       }
     end
@@ -69,7 +69,7 @@ class OrdersController < ApplicationController
 end
 ```
 
-### Configuration 
+### Configuration
 
 ### Layout file(.tlf) and options.
 
@@ -84,13 +84,13 @@ report.set_layout tlf: 'reports/index', layout_options: { default: true }
 
 ### generate options.
 ``` ruby
-report.generate_options(security: { 
+report.generate_options(security: {
   user_password: 'foo',
   owner_password: 'bar',
-  permissions: { 
+  permissions: {
     print_document: false,
     modify_contents: false,
-    copy_contents: false 
+    copy_contents: false
   }
 })
 ```
@@ -116,4 +116,3 @@ m(__)m, send me pull request.
 ## Copyright
 
 Copyright (c) 2012 Takeshi Shinoda.
-

--- a/gemfiles/Gemfile-rails.5.0.x
+++ b/gemfiles/Gemfile-rails.5.0.x
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gem 'rails', '~> 5.0.0'
+gemspec :path => '../'
+

--- a/gemfiles/Gemfile-rails.5.1.x
+++ b/gemfiles/Gemfile-rails.5.1.x
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'rails', '~> 5.1.0'
+gemspec :path => '../'

--- a/lib/thinreports-rails/template_handler.rb
+++ b/lib/thinreports-rails/template_handler.rb
@@ -4,7 +4,7 @@ require 'active_support/core_ext'
 require 'thinreports'
 
 module ThinreportsRails
-  class ThinreportsTemplate < SimpleDelegator  
+  class ThinreportsTemplate < SimpleDelegator
     attr_accessor :_generate_options
 
     def initialize(thinreports_report_base_obj, template_context, template_virtual_path)
@@ -56,8 +56,8 @@ module ThinreportsRails
           #{template.source}
         else
           generate_options = nil
-          ThinReports::Report.create do |__report__|
-            report = ThinreportsRails::ThinreportsTemplate.new(__report__, self, '#{template.virtual_path}') 
+          Thinreports::Report.create do |__report__|
+            report = ThinreportsRails::ThinreportsTemplate.new(__report__, self, '#{template.virtual_path}')
             report.set_layout :allow_no_layout => true
 
             #{template.source}
@@ -71,4 +71,3 @@ module ThinreportsRails
 end
 
 ActionView::Template.register_template_handler :thinreports, ThinreportsRails::TemplateHandler
-

--- a/test/thinreports-rails_test.rb
+++ b/test/thinreports-rails_test.rb
@@ -18,7 +18,7 @@ require 'rails/test_help'
 require 'thinreports-rails'
 require 'test_app/test_app'
 
-class ThinReportsRailsTest < ActionController::TestCase
+class ThinreportsRailsTest < ActionController::TestCase
   tests OrdersController
 
   test 'index.tlf is selected.' do
@@ -40,4 +40,3 @@ class ThinReportsRailsTest < ActionController::TestCase
     assert_raise(ActionView::Template::Error) { get :no_tlf, :format => :pdf }
   end
 end
-

--- a/thinreports-rails.gemspec
+++ b/thinreports-rails.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.name          = "thinreports-rails"
   gem.require_paths = ["lib"]
   gem.version       = ThinreportsRails::VERSION
-  gem.add_dependency "thinreports", '>= 0.9.1'
+  gem.add_dependency "thinreports", '>= 0.10.0'
 
   gem.add_development_dependency 'bundler', '>= 1.0.0'
 end


### PR DESCRIPTION
This PR contains all commits in #13 and added followings.

- Drop support for Ruby 1.9 and 2.0 as Thinreports does.
- Support Ruby 2.4.1.
- Add gemspecs for Rails 5.0 & 5.1.
- Update README for issues above.