### PR TITLE
Add support to Rails 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ rvm:
   - 2.4.1
   - 2.3.1
   - 2.2.4
-  - 2.2
   - 2.1
 
 gemfile:
@@ -20,17 +19,21 @@ gemfile:
   - gemfiles/Gemfile-rails.4.2.x
   - gemfiles/Gemfile-rails.5.0.x
   - gemfiles/Gemfile-rails.5.1.x
+  - gemfiles/Gemfile-rails.5.2.x
 
 matrix:
+  include:
+    - rvm: 2.5.6
+      gemfile: gemfiles/Gemfile-rails.6.0.x
+    - rvm: 2.6.4
+      gemfile: gemfiles/Gemfile-rails.6.0.x
   exclude:
     - rvm: 2.1
       gemfile: gemfiles/Gemfile-rails.5.0.x
     - rvm: 2.1
       gemfile: gemfiles/Gemfile-rails.5.1.x
-    - rvm: 2.2
-      gemfile: gemfiles/Gemfile-rails.5.0.x
-    - rvm: 2.2
-      gemfile: gemfiles/Gemfile-rails.5.1.x
+    - rvm: 2.1
+      gemfile: gemfiles/Gemfile-rails.5.2.x
     - rvm: 2.4.1
       gemfile: gemfiles/Gemfile-rails.3.0.x
     - rvm: 2.4.1

--- a/gemfiles/Gemfile-rails.5.2.x
+++ b/gemfiles/Gemfile-rails.5.2.x
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'rails', '~> 5.2.0'
+gemspec :path => '../'

--- a/gemfiles/Gemfile-rails.6.0.x
+++ b/gemfiles/Gemfile-rails.6.0.x
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'rails', '~> 6.0.0'
+gemspec :path => '../'

--- a/lib/thinreports-rails/template_handler.rb
+++ b/lib/thinreports-rails/template_handler.rb
@@ -50,17 +50,19 @@ module ThinreportsRails
     cattr_accessor :default_format
     self.default_format = 'application/pdf'
 
-    def self.call(template)
+    def self.call(template, source = nil)
+      source ||= template.source
+
       %{
         if defined?(report)
-          #{template.source}
+          #{source}
         else
           generate_options = nil
           Thinreports::Report.create do |__report__|
             report = ThinreportsRails::ThinreportsTemplate.new(__report__, self, '#{template.virtual_path}')
             report.set_layout :allow_no_layout => true
 
-            #{template.source}
+            #{source}
 
             generate_options = report._generate_options
           end.generate(*([generate_options].compact))


### PR DESCRIPTION
In Rails 6.0 the API for template handlers is changing, a template handler now take two arguments [1], the template and the source, otherwise you will see the following deprecation warning:

```
ActiveSupport::DeprecationException: DEPRECATION WARNING: Single arity
template handlers are deprecated.  Template handlers must now accept two
parameters, the view object and the source for the view object.
Change:
  >> Class#call(template)
To:
  >> Class#call(template, source)
```

[1] https://www.github.com/rails/rails/commit/28f88e0074

This fixes that deprecation warning.
Also, added test against latest Rails and Ruby and removed duplicates Ruby 2.2 test.

